### PR TITLE
Fix_memory_allocation_errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ LOCAL_SHELL_TEST	:= sh/test.sh
 
 # Debug flags
 ifeq ("$(VERSION_MODE)", "DEBUG")
-	DEBUG_INFO := -g -Wall
+	DEBUG_INFO := -g -Wall -fsanitize=address
 else
 	DEBUG_INFO :=
 endif

--- a/config.xml
+++ b/config.xml
@@ -3,7 +3,7 @@
     <Project_data
         version_major="2"
         version_minor="1"
-        version_mode="DEBUG"
+        version_mode="RELEASE"
         URL="https://github.com/JonMS95/C_Arg_Parse"
         type="library"
         language="C"
@@ -41,14 +41,14 @@
         <C_Severity_Log
             version_major="2"
             version_minor="3"
-            version_mode="DEBUG"
+            version_mode="RELEASE"
             local_path="~/Desktop/scripts/C/C_Severity_Log"
             URL="https://github.com/JonMS95/C_Severity_Log"
         />
         <C_Mutex_Guard
             version_major="1"
             version_minor="1"
-            version_mode="DEBUG"
+            version_mode="RELEASE"
             local_path="~/Desktop/scripts/C/C_Mutex_Guard"
             URL="https://github.com/JonMS95/C_Mutex_Guard"
         />
@@ -57,34 +57,34 @@
     <!-- Tests -->
     <!-- Paths to dependency files for the testing executable. -->
     <test>
-        <deps Dest="test/deps">
+        <deps Dest="test/deps" Sorted="Yes">
             <C_Arg_Parse
                 version_major="2"
                 version_minor="1"
-                version_mode="DEBUG"
+                version_mode="RELEASE"
                 local_path="."
                 URL="https://github.com/JonMS95/C_Arg_Parse"
             />
             <C_Severity_Log
                 version_major="2"
                 version_minor="3"
-                version_mode="DEBUG"
+                version_mode="RELEASE"
                 local_path="~/Desktop/scripts/C/C_Severity_Log"
                 URL="https://github.com/JonMS95/C_Severity_Log"
-            />
-            <C_Mutex_Guard
-                version_major="1"
-                version_minor="1"
-                version_mode="DEBUG"
-                local_path="~/Desktop/scripts/C/C_Mutex_Guard"
-                URL="https://github.com/JonMS95/C_Mutex_Guard"
             />
             <C_Signal_Handler
                 version_major="1"
                 version_minor="0"
-                version_mode="DEBUG"
+                version_mode="RELEASE"
                 local_path="~/Desktop/scripts/C/C_Signal_Handler"
                 URL="https://github.com/JonMS95/C_Signal_Handler"
+            />
+            <C_Mutex_Guard
+                version_major="1"
+                version_minor="1"
+                version_mode="RELEASE"
+                local_path="~/Desktop/scripts/C/C_Mutex_Guard"
+                URL="https://github.com/JonMS95/C_Mutex_Guard"
             />
             <Posix_Threads
                 type="APT_package"

--- a/config.xml
+++ b/config.xml
@@ -2,8 +2,8 @@
 <config>
     <Project_data
         version_major="2"
-        version_minor="0"
-        version_mode="RELEASE"
+        version_minor="1"
+        version_mode="DEBUG"
         URL="https://github.com/JonMS95/C_Arg_Parse"
         type="library"
         language="C"
@@ -29,7 +29,7 @@
     <!-- Common shell files location -->
     <Common_shell_files
         version_major="1"
-        version_minor="3"
+        version_minor="4"
         version_mode="RELEASE"
         local_path="~/C_Common_shell_files"
         URL="https://github.com/JonMS95/C_Common_shell_files"
@@ -40,10 +40,17 @@
     <deps Dest="deps">
         <C_Severity_Log
             version_major="2"
-            version_minor="0"
-            version_mode="RELEASE"
-            local_path="~/C_Severity_Log"
+            version_minor="3"
+            version_mode="DEBUG"
+            local_path="~/Desktop/scripts/C/C_Severity_Log"
             URL="https://github.com/JonMS95/C_Severity_Log"
+        />
+        <C_Mutex_Guard
+            version_major="1"
+            version_minor="1"
+            version_mode="DEBUG"
+            local_path="~/Desktop/scripts/C/C_Mutex_Guard"
+            URL="https://github.com/JonMS95/C_Mutex_Guard"
         />
     </deps>
     
@@ -51,19 +58,38 @@
     <!-- Paths to dependency files for the testing executable. -->
     <test>
         <deps Dest="test/deps">
-            <C_Severity_Log
-                version_major="2"
-                version_minor="0"
-                version_mode="RELEASE"
-                local_path="~/C_Severity_Log"
-                URL="https://github.com/JonMS95/C_Severity_Log"
-            />
             <C_Arg_Parse
                 version_major="2"
-                version_minor="0"
-                version_mode="RELEASE"
+                version_minor="1"
+                version_mode="DEBUG"
                 local_path="."
                 URL="https://github.com/JonMS95/C_Arg_Parse"
+            />
+            <C_Severity_Log
+                version_major="2"
+                version_minor="3"
+                version_mode="DEBUG"
+                local_path="~/Desktop/scripts/C/C_Severity_Log"
+                URL="https://github.com/JonMS95/C_Severity_Log"
+            />
+            <C_Mutex_Guard
+                version_major="1"
+                version_minor="1"
+                version_mode="DEBUG"
+                local_path="~/Desktop/scripts/C/C_Mutex_Guard"
+                URL="https://github.com/JonMS95/C_Mutex_Guard"
+            />
+            <C_Signal_Handler
+                version_major="1"
+                version_minor="0"
+                version_mode="DEBUG"
+                local_path="~/Desktop/scripts/C/C_Signal_Handler"
+                URL="https://github.com/JonMS95/C_Signal_Handler"
+            />
+            <Posix_Threads
+                type="APT_package"
+                lib_name="pthread"
+                package="libc6-dev"
             />
         </deps>
     </test>

--- a/src/GetOptions.c
+++ b/src/GetOptions.c
@@ -197,10 +197,6 @@ int CheckOptLowerOrEqual(int opt_var_type, OPT_DATA_TYPE min, OPT_DATA_TYPE max)
 
         case GET_OPT_TYPE_CHAR_STRING:
         {
-            // Expand boundaries if necessary (not likely to happen)
-            GetOptionsExpandPath(&min.char_string);
-            GetOptionsExpandPath(&max.char_string);
-
             char* minimum = min.char_string;
             char* maximum = max.char_string;
             
@@ -338,24 +334,6 @@ int FillPrivateOptStruct(   char            opt_char            ,
     return GET_OPT_SUCCESS;
 }
 
-/// @brief Expand path to server certificate and / or private key.
-/// @param src_short_str Path to be expanded.
-void GetOptionsExpandPath(char** src_short_str)
-{
-    if(src_short_str == NULL || *src_short_str == NULL)
-        return;
-    
-    if ((*src_short_str)[0] != '~')
-        return;
-
-    char* home_dir = getenv(GET_OPT_HOME_OS_DIR_NAME);
-    char* aux      = (char*)calloc(strlen(*src_short_str) + 1, 1);
-    strcpy(aux, *src_short_str + 1);
-    *src_short_str = (char*)calloc(strlen(home_dir) + strlen(aux), 1);
-    strcpy(*src_short_str, home_dir);
-    strcpy(*src_short_str + strlen(*src_short_str), aux);
-}
-
 //////////////////////////////////////////////////////////////////////////////
 /// @brief Gets and checks option definition.
 /// @param opt_char Option character.
@@ -405,9 +383,6 @@ int SetOptionDefinition(char            opt_char            ,
         return GET_OPT_ERR_NO_OPT_LONG;
     }
 
-    // Expand long option if necessary (not likely to happen)
-    GetOptionsExpandPath(&opt_long);
-
     // If option long string exists, then check if its length exceeds the allowed maximum.
     if(opt_long != NULL)
     {
@@ -436,9 +411,6 @@ int SetOptionDefinition(char            opt_char            ,
                 opt_char                    ,
                 opt_long                    );
     }
-
-    // Expand detail if necessary (not likely to happen)
-    GetOptionsExpandPath(&opt_detail);
 
     // If option detail exists, then check if its length exceeds the allowed maximum.
     if(opt_detail != NULL)
@@ -510,19 +482,6 @@ int SetOptionDefinition(char            opt_char            ,
         }
     }
 
-    // Even if no boundaries are established for the current parameter, if it is a string, then expand if it required.
-    if(opt_var_type == GET_OPT_TYPE_CHAR_STRING)
-    {
-        if(opt_min_value.char_string != NULL)
-            GetOptionsExpandPath(&(opt_min_value.char_string));
-
-        if(opt_max_value.char_string != NULL)
-            GetOptionsExpandPath(&(opt_max_value.char_string));
-
-        if(opt_default_value.char_string != NULL)
-            GetOptionsExpandPath(&(opt_default_value.char_string));
-    }
-
     // Check whether the pointer to the target output variable is null or not.
     if(opt_dest_var == NULL)
     {
@@ -590,7 +549,7 @@ int GetOptDefFromStruct(PUB_OPT_DEFINITION* pub_opt_def, int pub_opt_def_size)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 int GenerateShortOptStr(void)
 {
-    if(private_options        == NULL)
+    if(private_options == NULL)
     {
         SVRTY_LOG_DBG("FILE: %s\tFUNCTION: %s\tLINE: %d", __FILE__, __func__, __LINE__);
         return GET_OPT_ERR_NULL_PTR;
@@ -625,7 +584,7 @@ int GenerateShortOptStr(void)
         }
     }
 
-    short_options_string = (char*)calloc(strlen(aux_short_options), sizeof(char));
+    short_options_string = (char*)calloc(strlen(aux_short_options) + 1, sizeof(char));
     strcpy(short_options_string, aux_short_options);
 
     return GET_OPT_SUCCESS;
@@ -702,7 +661,6 @@ void CastParsedArgument(PRIV_OPT_DEFINITION* priv_opt_def, char* arg, OPT_DATA_T
 
         case GET_OPT_TYPE_CHAR_STRING:
         {
-            GetOptionsExpandPath(&arg);
             dest->char_string = arg;
         }
         break;
@@ -754,7 +712,6 @@ void AssignValue(PRIV_OPT_DEFINITION* priv_opt_def, OPT_DATA_TYPE src)
 
         case GET_OPT_TYPE_CHAR_STRING:
         {
-            GetOptionsExpandPath(&(src.char_string));
             strcpy((char*)(priv_opt_def->pub_opt.opt_dest_var), src.char_string);
         }
         break;

--- a/test/src/main.c
+++ b/test/src/main.c
@@ -268,12 +268,15 @@ int TestParseOptions(int argc, char** argv)
 
     SVRTY_LOG_INF("********** ParseOptions Test End **********");
 
+    free(test_4);
+    test_4 = NULL;
+
     return (parse_options < 0) ? parse_options : GET_OPT_SUCCESS;
 }
 
 int main(int argc, char **argv)
 {
-    SeverityLogInit(1000, SVRTY_LOG_MASK_ALL, true, false, true);
+    SeverityLogInitWithMask(1000, 0xFF);
 
     Test_SetOptionDefinition();
 


### PR DESCRIPTION
Fixed many memory allocation errors.
Strings are no longer expanded by default (the fact that a string starts with ~ does not mean it represents a path although it's the most common outcome).